### PR TITLE
docs: add badges and table of contents for better discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 **English** | [中文](./README.zh-CN.md)
 
+[![GitHub stars](https://img.shields.io/github/stars/zhu1090093659/spec_driven_develop?style=social)](https://github.com/zhu1090093659/spec_driven_develop/stargazers)
+[![Forks](https://img.shields.io/github/forks/zhu1090093659/spec_driven_develop?style=social)](https://github.com/zhu1090093659/spec_driven_develop/fork)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Platform](https://img.shields.io/badge/Platform-Claude%20Code%20%7C%20Codex%20%7C%20Cursor-FF6B6B.svg)](https://github.com)
+
+## Table of Contents
+- [Why Not Superpowers / oh-my-claude / ...?](#why-not-superpowers--oh-my-claude--)
+- [Platform Compatibility](#platform-compatibility)
+- [Installation](#installation)
+- [How It Works](#how-it-works)
+- [Friendly Links](#friendly-links)
+- [License](#license)
+
 # Spec-Driven Develop
 
 **One Markdown file. Any coding agent. Full pre-development automation.**


### PR DESCRIPTION
Hi! I noticed the README is very well-written but could benefit from a few visibility improvements:

- **Badges** for stars, forks, license, and platform compatibility — helps GitHub search and makes the repo look more established
- **Table of Contents** — with ~10K words, it helps users navigate the comparison table and installation sections

These are purely cosmetic additions, no code changes. The existing content is excellent as-is.

*This PR was created by a growth automation agent. For AI agent launch strategies, see [Gingiris/gingiris-opensource](https://github.com/Gingiris/gingiris-opensource).*