### PR TITLE
[Batch P1-B1] Foundation & Guard: stale-ref cleanup, hygiene, and the validate.sh consistency guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 __pycache__/
 *.pyc
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ These instructions apply to the whole repository.
 - Core workflow: `plugins/spec-driven-develop/skills/spec-driven-develop/SKILL.md`
 - Shared workflow references: `plugins/spec-driven-develop/skills/spec-driven-develop/references/`
 - Claude Code sub-agent prompts: `plugins/spec-driven-develop/agents/`
+- OpenCode plugin entrypoint: `plugins/spec-driven-develop/opencode-plugin.js`
+- Plugin manifests: `plugins/spec-driven-develop/.claude-plugin/plugin.json`, `plugins/spec-driven-develop/.codex-plugin/plugin.json`, and the root `.claude-plugin/marketplace.json`
+- Validation and helper scripts: `scripts/`
 - User-facing docs: `README.md` and `README.zh-CN.md`
 - Persistent project memory: use the active coding agent's native project memory surface when available. Do not add a repository fallback memory file unless the workflow explicitly records that choice.
 
@@ -23,9 +26,9 @@ These instructions apply to the whole repository.
 
 ## Validation
 
-Use the closest checks for the changed surface:
+Run the standing consistency guard first; it subsumes the Python byte-compile check. Then use the closest checks for the changed surface:
 
-- `python -m py_compile scripts/export-progress.py`
+- `bash scripts/validate.sh`
 - `bash -n scripts/install-codex.sh scripts/install-cursor.sh scripts/install-opencode.sh scripts/install-all.sh`
 - Targeted `rg` checks for newly required workflow language
 - `git diff --check`

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Use this section when summarizing or citing Spec-Driven Develop in search result
 
 ## What It Does
 
-When you tell your agent something like "rewrite this project in Rust" or "migrate to a microservice architecture", Spec-Driven Develop kicks in with a 6-phase pipeline:
+When you tell your agent something like "rewrite this project in Rust" or "migrate to a microservice architecture", Spec-Driven Develop kicks in with a seven-phase pipeline (Phases 0-6):
 
 ```
 Phase 0  Quick Intent Capture      Capture high-level direction (1-2 sentences)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,7 +53,7 @@ Spec-Driven Develop 是一个开源、平台无关的 AI Coding Agent 工作流�
 
 ## 它做什么
 
-当你对 Agent 说"把这个项目用 Rust 重写"或"迁移到微服务架构"时，Spec-Driven Develop 会启动一条 6 阶段的流水线：
+当你对 Agent 说"把这个项目用 Rust 重写"或"迁移到微服务架构"时，Spec-Driven Develop 会启动一条 7 阶段的流水线（Phase 0-6）：
 
 ```
 Phase 0  快速意图捕获              捕获高层方向（1-2 句话）

--- a/plugins/spec-driven-develop/.codex-plugin/plugin.json
+++ b/plugins/spec-driven-develop/.codex-plugin/plugin.json
@@ -26,7 +26,7 @@
   "interface": {
     "displayName": "Spec-Driven Develop",
     "shortDescription": "Architecture-first planning, deep discussion, and findings-first code review for AI coding agents.",
-    "longDescription": "Spec-Driven Develop adds three Markdown-based workflows for Codex: a six-phase development pipeline for large project transformations (analysis, planning, project governance, tracking, and execution), Deep Discuss for disciplined problem analysis and solution design, and Review SPD for bug-focused code review of uncommitted changes, date-range commits, and branch/PR diffs.",
+    "longDescription": "Spec-Driven Develop adds three Markdown-based workflows for Codex: a seven-phase development pipeline (Phases 0-6) for large project transformations (analysis, planning, project governance, tracking, and execution), Deep Discuss for disciplined problem analysis and solution design, and Review SPD for bug-focused code review of uncommitted changes, date-range commits, and branch/PR diffs.",
     "developerName": "zhu1090093659",
     "category": "Productivity",
     "capabilities": [

--- a/plugins/spec-driven-develop/agents/project-analyzer.md
+++ b/plugins/spec-driven-develop/agents/project-analyzer.md
@@ -80,15 +80,6 @@ Be specific. Always include file paths and line references. Estimate sizes with 
 
 ## Optional: GitHub Pre-flight Check
 
-If instructed by the orchestrator, run the GitHub integration pre-flight check after completing the analysis. This determines the task tracking mode for the workflow.
-
-```bash
-# Check gh CLI, auth, repo, issue access, and project access
-gh --version > /dev/null 2>&1 && \
-gh auth status > /dev/null 2>&1 && \
-gh repo view --json nameWithOwner -q '.nameWithOwner' > /dev/null 2>&1 && \
-gh issue list --limit 1 > /dev/null 2>&1 && \
-{ gh project list --limit 1 > /dev/null 2>&1 && echo "GITHUB_FULL" || echo "GITHUB_STANDARD"; } || echo "LOCAL_ONLY"
-```
+If instructed by the orchestrator, run the GitHub integration pre-flight check after completing the analysis. Follow `references/github-integration.md` § "Pre-flight Check" exactly — do not substitute a shortened inline pipeline. This determines the task tracking mode for the workflow.
 
 Append the detected mode to your analysis output under a `## GitHub Integration Mode` section.

--- a/plugins/spec-driven-develop/skills/spec-driven-develop/SKILL.md
+++ b/plugins/spec-driven-develop/skills/spec-driven-develop/SKILL.md
@@ -137,7 +137,7 @@ After loading your current state, populate the platform's native task tracking t
 
 3. Summarize the refined understanding back to the user and get explicit confirmation before proceeding.
 
-**Output**: A clear, confirmed task definition grounded in project reality. This is the authoritative task definition that guides all subsequent phases (Phase 3-7).
+**Output**: A clear, confirmed task definition grounded in project reality. This is the authoritative task definition that guides all subsequent phases (Phases 3-6).
 
 ---
 

--- a/plugins/spec-driven-develop/skills/spec-driven-develop/references/adaptive-control.md
+++ b/plugins/spec-driven-develop/skills/spec-driven-develop/references/adaptive-control.md
@@ -12,7 +12,7 @@ The workflow is modeled as a **closed-loop control system**:
 |:-----------------------|:-----------------|
 | **Plant** (被控对象) | The codebase under transformation |
 | **Set point** (目标) | Phase 2 confirmed task definition + S.U.P.E.R principles |
-| **Controller** | The SKILL workflow (Phases 0-7) + this adaptive protocol |
+| **Controller** | The SKILL workflow (Phases 0-6) + this adaptive protocol |
 | **Actuator** | Delivery batch executors and lane workers (sequential or parallel) |
 | **Sensor** | Post-task telemetry collection |
 | **Error signal** | `drift_score` — cumulative plan-vs-reality deviation |

--- a/plugins/spec-driven-develop/skills/spec-driven-develop/references/adaptive-control.md
+++ b/plugins/spec-driven-develop/skills/spec-driven-develop/references/adaptive-control.md
@@ -41,7 +41,7 @@ Record the **effort delta** as the number of levels between estimated and actual
 
 ### 1.2 S.U.P.E.R Score Delta
 
-Run the S.U.P.E.R Code Review Checklist (10 checks). Compare the pass count against the task's baseline expectation:
+Run the S.U.P.E.R Code Review Checklist (10 checks) defined in `super-philosophy.md` § "S.U.P.E.R Code Review Checklist (10 checks)". Compare the pass count against the task's baseline expectation:
 - If the task's S.U.P.E.R drivers indicated it should improve specific principles, and the checklist shows improvement → delta = positive
 - If the checklist shows no improvement where improvement was expected → delta = 0 (counts as deviation)
 - If the checklist shows regression → delta = negative

--- a/plugins/spec-driven-develop/skills/spec-driven-develop/references/parallel-protocol.md
+++ b/plugins/spec-driven-develop/skills/spec-driven-develop/references/parallel-protocol.md
@@ -1,6 +1,6 @@
 # Parallel Execution Protocol
 
-This protocol defines how the generated sub-SKILL (and the agent using it) should leverage sub-agents during actual development work. Issues are task units; delivery batches are integration and PR units. It applies throughout the implementation, not to a specific phase.
+This protocol defines how the agent should leverage sub-agents during actual development work. Issues are task units; delivery batches are integration and PR units. It applies throughout the implementation, not to a specific phase.
 
 ---
 
@@ -27,7 +27,7 @@ For each parallel lane in the current dependency-ready wave:
    - Per-task acceptance criteria, test expectations, and explicit no-test rationales, if any
    - Per-task memory/governance impact and expected surface updates, if any
    - Relevant source file paths (from `docs/analysis/module-inventory.md`)
-   - Coding standards from the sub-SKILL
+   - Coding standards from the orchestrator's dispatch input
    - Current project governance context from the resolved instruction and memory surfaces
    - Summary of completed prerequisite tasks and their outputs
 

--- a/plugins/spec-driven-develop/skills/spec-driven-develop/references/super-philosophy.md
+++ b/plugins/spec-driven-develop/skills/spec-driven-develop/references/super-philosophy.md
@@ -125,3 +125,24 @@ The natural consequence and ultimate goal of S + U + P + E.
 |  3+ No   -> Technical debt alert         |
 +------------------------------------------+
 ```
+
+---
+
+## S.U.P.E.R Code Review Checklist (10 checks)
+
+Run this checklist after every task before marking it complete. This is the agent-canonical copy of the checklist also shown in the user-facing README; keep the two in sync.
+
+| Check | Principle |
+|:------|:----------|
+| Every new module/file has exactly one responsibility | S |
+| No function does more than one conceptual thing | S |
+| Data flows input → processing → output, no reverse deps | U |
+| No circular imports introduced | U |
+| Cross-module interfaces are schema-defined | P |
+| Module I/O is serializable | P |
+| No hardcoded paths, URLs, keys, or config values | E |
+| All new dependencies explicitly declared | E |
+| New modules can be replaced without changes to others | R |
+| All tests pass after the change | — |
+
+**Scoring rule:** All pass = proceed. 1-2 fail = fix before marking complete. 3+ fail = stop and refactor.

--- a/plugins/spec-driven-develop/skills/spec-driven-develop/references/templates/archive.md
+++ b/plugins/spec-driven-develop/skills/spec-driven-develop/references/templates/archive.md
@@ -9,7 +9,7 @@ Templates for Phase 6 (Archive). Output to `docs/archives/`.
 ```markdown
 # Project Archives
 
-This directory contains archived artifacts from completed Spec-Driven Develop workflows. Each subdirectory represents one development project, preserving its full analysis, plan, progress history, and task-specific skill for future reference.
+This directory contains archived artifacts from completed Spec-Driven Develop workflows. Each subdirectory represents one development project, preserving its full analysis, plan, and progress history for future reference.
 
 | Project | Description | Period | Mode | Progress |
 |:--------|:------------|:-------|:-----|:---------|
@@ -36,13 +36,11 @@ docs/archives/<project-name>/
 │   ├── MASTER.md
 │   ├── phase-1-<short-name>.md
 │   └── ...
-├── governance/
-│   ├── instruction-surfaces.md
-│   ├── AGENTS.md              # if resolved and file-backed
-│   ├── CLAUDE.md              # if resolved and file-backed
-│   └── memory-surface.md      # export note or fallback snapshot, if available
-└── skill/
-    └── SKILL.md
+└── governance/
+    ├── instruction-surfaces.md
+    ├── AGENTS.md              # if resolved and file-backed
+    ├── CLAUDE.md              # if resolved and file-backed
+    └── memory-surface.md      # export note or fallback snapshot, if available
 ```
 
 Archive governance surfaces as snapshots or export notes only. Keep active instruction and memory surfaces in place after archiving. If memory is native and cannot be exported, record its platform/name and the key decisions that were written there.

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -9,7 +9,7 @@ TARGET_SKILLS_DIR="$CODEX_HOME/skills"
 TARGET_DIR="$TARGET_SKILLS_DIR/$SKILL_NAME"
 SKILLS_SUBPATH="plugins/spec-driven-develop/skills"
 SKILL_SUBPATH="$SKILLS_SUBPATH/$SKILL_NAME"
-BUNDLED_SKILLS=("spec-driven-develop" "deep-discuss" "review" "review-spd")
+BUNDLED_SKILLS=("spec-driven-develop" "deep-discuss" "review-spd")
 
 # Extract version from SKILL.md frontmatter
 extract_version() {

--- a/scripts/install-cursor.sh
+++ b/scripts/install-cursor.sh
@@ -8,7 +8,7 @@ TARGET_SKILLS_DIR="$HOME/.cursor/skills"
 TARGET_DIR="$TARGET_SKILLS_DIR/$SKILL_NAME"
 SKILLS_SUBPATH="plugins/spec-driven-develop/skills"
 SKILL_SUBPATH="$SKILLS_SUBPATH/$SKILL_NAME"
-BUNDLED_SKILLS=("spec-driven-develop" "deep-discuss" "review" "review-spd")
+BUNDLED_SKILLS=("spec-driven-develop" "deep-discuss" "review-spd")
 
 # Extract version from SKILL.md frontmatter
 extract_version() {

--- a/scripts/test-fixtures/progress/MASTER.md
+++ b/scripts/test-fixtures/progress/MASTER.md
@@ -1,0 +1,43 @@
+# Exporter Smoke Fixture -- Progress Tracker
+
+> **Task**: Provide a known-good LOCAL_ONLY progress tree for the exporter smoke test
+> **Started**: 2026-01-01
+> **Last Updated**: 2026-01-01
+> **Mode**: LOCAL_ONLY
+
+## References
+- [Task Breakdown](../plan/task-breakdown.md)
+
+## Phase Summary
+
+| Phase | Name | Tasks | Done | Progress |
+|:------|:-----|------:|-----:|:---------|
+| 1     | Foundation |     2 |    0 | 0%       |
+
+## Phase Checklist
+- [ ] Phase 1: Foundation (0/2 tasks) — [details](./phase-1-foundation.md)
+
+## Current Status
+<!-- Updated by the agent at the start and end of each work session -->
+**Active Phase**: Phase 1
+**Active Task**: Create the progress fixture tree
+**Blockers**: None
+
+## Governance Status
+<!-- Updated when project-level agent rules or durable memory change -->
+**Shared instruction surface**: `AGENTS.md`
+**Claude Code instruction surface**: `CLAUDE.md`
+**Other platform rule surfaces**: none
+**Memory surface**: native
+**Memory fallback path**: none
+
+## Next Steps
+<!-- What the agent should do next when resuming in a new conversation -->
+1. Complete Task 1.1
+2. Complete Task 1.2
+
+## Session Log
+<!-- Append-only log of work sessions -->
+| Date | Session | Summary |
+|:-----|:--------|:--------|
+|      |         |         |

--- a/scripts/test-fixtures/progress/phase-1-foundation.md
+++ b/scripts/test-fixtures/progress/phase-1-foundation.md
@@ -1,0 +1,29 @@
+# Phase 1: Foundation
+
+**Goal**: Establish a minimal known-good progress tree for exporter smoke testing
+**Status**: In Progress
+
+## Tasks
+- [ ] **Task 1.1**: Create the progress fixture tree
+  - Priority: P0
+  - Effort: S
+  - Test Expectation: Smoke-test the exporter against this fixture
+  - Memory Impact: None
+  - Acceptance: Exporter parses exactly two tasks from this file
+  - Notes: _none yet_
+- [ ] **Task 1.2**: Verify exporter JSON output
+  - Priority: P1
+  - Effort: S
+  - Test Expectation: Assert JSON structure inside the validation script
+  - Memory Impact: None
+  - Acceptance: JSON reports one phase with two total tasks and two parsed tasks
+  - Notes: _none yet_
+
+## Phase Notes
+<!-- Decisions, blockers, context discovered during this phase -->
+Fixture for the exporter smoke test. Follows the LOCAL_ONLY progress format.
+
+## Phase Completion Checklist
+- [ ] All tasks above are checked off
+- [ ] MASTER.md phase count updated
+- [ ] MASTER.md "Current Status" updated to next phase

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+#
+# scripts/validate.sh — standing consistency guard for the spec_driven_develop repo.
+#
+# Runs seven checks and prints one PASS/FAIL line per check. Exits non-zero if any
+# check fails. Safe to run from any directory: the script cds to the repo root
+# (the parent of this scripts/ directory) before doing any work.
+#
+# Dependencies (no new ones introduced):
+#   - bash
+#   - python3 (standard library only)
+#   - node   (required for check (e); absence is a loud FAILURE, not a skip)
+#   - git    (used to enumerate tracked files for check (a))
+#
+# Design choice (per task T1.4): path-reference extraction in check (a) is
+# implemented in python3 stdlib rather than ripgrep (rg). This keeps the guard
+# free of any rg dependency so it runs identically on machines without ripgrep.
+#
+# Checks:
+#   (a) Reference existence  — backtick-quoted relative paths found in tracked
+#        .md/.json/.js files must resolve to an existing file/dir. Candidates
+#        containing template placeholders (<, >, {, }, *) or whitespace are
+#        skipped. Resolution rules:
+#          * paths starting with plugins/ or scripts/ resolve from the repo root;
+#          * paths containing a references/, agents/, or templates/ segment that
+#            name a file (basename has an extension) are tried against the repo
+#            root, the referencing file's directory and each of its ancestors,
+#            and every skill root (plugins/*\/skills/*/). The first base that
+#            resolves wins. This matches how the skills and agent prompts write
+#            skill-internal references (relative to the skill root).
+#        docs/archives/ is excluded from scanning: those are frozen historical
+#        snapshots whose internal references are intentionally not maintained.
+#   (b) Manifest <-> filesystem parity — for plugins/spec-driven-develop/
+#        .claude-plugin/plugin.json: every path in its agents (and commands, while
+#        present) arrays exists on disk; no unlisted files live in agents/ (or
+#        commands/); and every readPrompt("...") literal in opencode-plugin.js
+#        resolves. An absent commands array is TOLERATED (it is slated for
+#        deletion in a later phase, which must not require editing this script).
+#   (c) Version parity — the version string must be identical across four sites:
+#        SKILL.md frontmatter, .claude-plugin/plugin.json, .codex-plugin/
+#        plugin.json, and the root .claude-plugin/marketplace.json (.plugins[0]).
+#   (d) JSON validity — the four manifests above plus .agents/plugins/
+#        marketplace.json must each parse as JSON.
+#   (e) ESM syntax — `node --check --input-type=module` on opencode-plugin.js
+#        (plain `node --check` parses as CommonJS and fails on `import`).
+#   (f) py_compile — the three Python files must byte-compile.
+#   (g) Exporter smoke test — run scripts/export-progress.py against the
+#        known-good fixture in scripts/test-fixtures/progress/ and assert the
+#        JSON structure (task name, one phase with two tasks, two parsed tasks
+#        with non-empty priority/acceptance).
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT"
+
+FAILURES=0
+
+run_check() {
+  local id="$1"; shift
+  local desc="$1"; shift
+  if "$@"; then
+    echo "[PASS] ($id) $desc"
+  else
+    echo "[FAIL] ($id) $desc"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# (a) Reference existence
+# ---------------------------------------------------------------------------
+check_a() {
+  python3 - <<'PY'
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(".").resolve()
+EXCLUDE_PREFIX = "docs/archives/"
+SEGMENTS = ("references/", "agents/", "templates/")
+SKIP_CHARS = set("<>{}*")
+BACKTICK = re.compile(r"`([^`\n]+)`")
+
+try:
+    tracked = subprocess.check_output(["git", "ls-files"], text=True).splitlines()
+except Exception as exc:  # pragma: no cover - git should always be present here
+    print(f"check (a): cannot enumerate tracked files: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+files = [
+    f for f in tracked
+    if f.endswith((".md", ".json", ".js")) and not f.startswith(EXCLUDE_PREFIX)
+]
+
+SKILL_ROOTS = sorted(ROOT.glob("plugins/*/skills/*/"))
+
+
+def classify(candidate):
+    c = candidate.strip()
+    if not c or any(ch in c for ch in SKIP_CHARS):
+        return None
+    if any(ch.isspace() for ch in c):
+        return None
+    if c.startswith(("plugins/", "scripts/")):
+        return ("root", c)
+    for seg in SEGMENTS:
+        if c.startswith(seg) or ("/" + seg) in c:
+            base = c.rstrip("/").rsplit("/", 1)[-1]
+            if "." in base:  # names a file rather than a bare directory segment
+                return ("rel", c)
+            return None
+    return None
+
+
+def rel_bases(referencing_file):
+    yield ROOT
+    parent = (ROOT / referencing_file).parent
+    while True:
+        yield parent
+        if parent == ROOT:
+            break
+        parent = parent.parent
+    for sr in SKILL_ROOTS:
+        yield sr
+
+
+def resolves(kind, candidate, referencing_file):
+    if kind == "root":
+        return (ROOT / candidate).exists()
+    return any((b / candidate).exists() for b in rel_bases(referencing_file))
+
+
+missing = []
+for f in files:
+    try:
+        text = (ROOT / f).read_text(encoding="utf-8")
+    except OSError:
+        continue  # tracked but unreadable/removed on disk; nothing to scan
+    for m in BACKTICK.finditer(text):
+        cl = classify(m.group(1))
+        if not cl:
+            continue
+        kind, candidate = cl
+        if not resolves(kind, candidate, f):
+            missing.append((candidate, f))
+
+if missing:
+    for candidate, f in missing:
+        print(f"check (a): broken reference `{candidate}` in {f}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# (b) Manifest <-> filesystem parity
+# ---------------------------------------------------------------------------
+check_b() {
+  python3 - <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+PLUGIN = Path("plugins/spec-driven-develop")
+MANIFEST = PLUGIN / ".claude-plugin" / "plugin.json"
+
+errors = []
+try:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+except Exception as exc:
+    print(f"check (b): cannot parse {MANIFEST}: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+# 1) Every path listed in agents/ (and commands/, while present) exists; and
+# 2) no unlisted files live in the corresponding directory. An absent key is
+#    tolerated so a future phase that drops `commands` needs no edit here.
+for key in ("agents", "commands"):
+    entries = manifest.get(key)
+    if entries is None:
+        continue
+    listed_names = set()
+    for entry in entries:
+        listed_names.add(Path(entry).name)
+        if not (PLUGIN / entry).exists():
+            errors.append(f"listed {key} entry missing on disk: {entry}")
+    directory = PLUGIN / key
+    if directory.is_dir():
+        for f in sorted(directory.iterdir()):
+            if f.is_file() and f.name not in listed_names:
+                errors.append(f"unlisted file in {key}/: {f.name}")
+
+# 3) Every readPrompt("...") literal in opencode-plugin.js resolves.
+js_path = PLUGIN / "opencode-plugin.js"
+try:
+    js = js_path.read_text(encoding="utf-8")
+except OSError as exc:
+    errors.append(f"cannot read {js_path}: {exc}")
+else:
+    for m in re.finditer(r"readPrompt\([\"']([^\"']+)[\"']\)", js):
+        rel = m.group(1)
+        if not (PLUGIN / rel).exists():
+            errors.append(f"readPrompt target missing: {rel}")
+
+if errors:
+    for e in errors:
+        print(f"check (b): {e}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# (c) Version parity
+# ---------------------------------------------------------------------------
+check_c() {
+  python3 - <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+PLUGIN = Path("plugins/spec-driven-develop")
+
+
+def skill_version():
+    text = (PLUGIN / "skills" / "spec-driven-develop" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    fm = re.match(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
+    block = fm.group(1) if fm else text
+    m = re.search(r"^\s*version:\s*(.+?)\s*$", block, re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def json_version(path, key_path):
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"check (c): cannot parse {path}: {exc}", file=sys.stderr)
+        return None
+    node = data
+    for key in key_path:
+        if not isinstance(node, (dict, list)):
+            return None
+        try:
+            node = node[key]
+        except (KeyError, IndexError, TypeError):
+            return None
+    return node
+
+
+versions = {
+    "SKILL.md frontmatter": skill_version(),
+    "plugins/spec-driven-develop/.claude-plugin/plugin.json": json_version(
+        PLUGIN / ".claude-plugin" / "plugin.json", ["version"]
+    ),
+    "plugins/spec-driven-develop/.codex-plugin/plugin.json": json_version(
+        PLUGIN / ".codex-plugin" / "plugin.json", ["version"]
+    ),
+    ".claude-plugin/marketplace.json": json_version(
+        ".claude-plugin/marketplace.json", ["plugins", 0, "version"]
+    ),
+}
+
+distinct = set(versions.values())
+if None in distinct or len(distinct) != 1:
+    for site, value in versions.items():
+        print(f"check (c):   {site}: {value}", file=sys.stderr)
+    print("check (c): version mismatch across sites", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# (d) JSON validity
+# ---------------------------------------------------------------------------
+check_d() {
+  python3 - <<'PY'
+import json
+import sys
+from pathlib import Path
+
+MANIFESTS = [
+    "plugins/spec-driven-develop/.claude-plugin/plugin.json",
+    "plugins/spec-driven-develop/.codex-plugin/plugin.json",
+    ".claude-plugin/marketplace.json",
+    ".agents/plugins/marketplace.json",
+]
+
+bad = []
+for f in MANIFESTS:
+    try:
+        json.loads(Path(f).read_text(encoding="utf-8"))
+    except Exception as exc:
+        bad.append(f"{f}: {exc}")
+
+if bad:
+    for b in bad:
+        print(f"check (d): invalid JSON {b}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# (e) ESM syntax of the OpenCode plugin entrypoint
+# ---------------------------------------------------------------------------
+check_e() {
+  if ! command -v node >/dev/null 2>&1; then
+    echo "check (e): node not found; cannot run ESM syntax check" >&2
+    return 1
+  fi
+  node --check --input-type=module < plugins/spec-driven-develop/opencode-plugin.js
+}
+
+# ---------------------------------------------------------------------------
+# (f) py_compile the Python sources
+# ---------------------------------------------------------------------------
+check_f() {
+  python3 -m py_compile \
+    scripts/export-progress.py \
+    scripts/review-context.py \
+    plugins/spec-driven-develop/skills/review-spd/scripts/review-context.py
+}
+
+# ---------------------------------------------------------------------------
+# (g) Exporter smoke test against the known-good fixture
+# ---------------------------------------------------------------------------
+check_g() {
+  python3 - <<'PY'
+import json
+import subprocess
+import sys
+
+result = subprocess.run(
+    [sys.executable, "scripts/export-progress.py", "scripts/test-fixtures/progress/"],
+    capture_output=True,
+    text=True,
+)
+if result.returncode != 0:
+    print(f"check (g): exporter exited {result.returncode}: {result.stderr.strip()}",
+          file=sys.stderr)
+    sys.exit(1)
+
+try:
+    data = json.loads(result.stdout)
+except json.JSONDecodeError as exc:
+    print(f"check (g): exporter output is not valid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+errors = []
+if data.get("task") != "Exporter Smoke Fixture":
+    errors.append(f"unexpected task name: {data.get('task')!r}")
+
+phases = data.get("phases", [])
+if len(phases) != 1:
+    errors.append(f"expected 1 phase, got {len(phases)}")
+else:
+    phase = phases[0]
+    if phase.get("total_tasks") != 2:
+        errors.append(f"expected total_tasks == 2, got {phase.get('total_tasks')}")
+    tasks = phase.get("tasks", [])
+    if len(tasks) != 2:
+        errors.append(f"expected 2 parsed tasks, got {len(tasks)}")
+    for t in tasks:
+        if not t.get("priority"):
+            errors.append(f"task {t.get('id')} has empty priority")
+        if not t.get("acceptance"):
+            errors.append(f"task {t.get('id')} has empty acceptance")
+
+if errors:
+    for e in errors:
+        print(f"check (g): {e}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# Run all checks
+# ---------------------------------------------------------------------------
+run_check a "reference existence" check_a
+run_check b "manifest <-> filesystem parity" check_b
+run_check c "version parity" check_c
+run_check d "JSON validity of manifests" check_d
+run_check e "ESM syntax of opencode-plugin.js" check_e
+run_check f "py_compile Python sources" check_f
+run_check g "exporter smoke test (fixture)" check_g
+
+echo
+if [ "$FAILURES" -gt 0 ]; then
+  echo "validate.sh: $FAILURES check(s) FAILED" >&2
+  exit 1
+fi
+echo "validate.sh: all 7 checks passed"
+exit 0


### PR DESCRIPTION
## Problem Statement (real usage problems addressed)

1. **No consistency guard existed** — every prior workflow restructure (v1.10, v1.11) left cross-surface drift behind: the phase count was stated three different ways ("Phases 0-7", "Phase 3-7", "six-phase"), removed sub-SKILL references survived in two files, and a "S.U.P.E.R Code Review Checklist (10 checks)" was invoked by adaptive-control.md but defined only in the README (not agent-readable).
2. **Installers carried a legacy `review` skill entry** and lane worktrees had no gitignore coverage.
3. **AGENTS.md's Truth Sources/Validation were incomplete** — omitted opencode-plugin.js, the manifests, and scripts/; the py_compile check covered only 1 of 3 Python files.

## Batch Rationale

One coherent "stop the drift + install the guard" unit. Every later batch (execution-model rewrite, prompt single-sourcing, commands/ deletion) depends on this guard existing first — rewrites without it would re-encode drift with no net to catch contract breakage.

## Included Issues

Closes #14
Closes #15
Closes #16
Closes #17
Closes #18

| Issue | Task | Acceptance | Targeted Validation |
|:------|:-----|:-----------|:--------------------|
| #14 | T1.1 stale refs | complete | rg sweeps zero hits (sub-SKILL, phase counts) |
| #15 | T1.2 10-check relocation | complete | table diff vs README: identical |
| #16 | T1.3 hygiene | complete | junk globs empty; bash -n installers |
| #17 | T1.4 validate.sh + fixture | complete | 7 checks PASS incl. negative-path verification |
| #18 | T1.5 AGENTS.md repair | complete | validate.sh exits 0 |

## Changes

- **NEW `scripts/validate.sh`** (401 lines): 7 checks — (a) reference existence with multi-base resolution; (b) manifest↔filesystem parity (tolerates absent `commands` array, required for the later deletion batch); (c) 4-site version parity; (d) JSON validity; (e) node ESM check; (f) py_compile ×3; (g) exporter smoke test against a new fixture. Negative paths verified in a throwaway copy.
- **NEW `scripts/test-fixtures/progress/`**: known-good LOCAL_ONLY fixture for check (g).
- **Stale refs fixed** across SKILL.md, adaptive-control.md, parallel-protocol.md, templates/archive.md, project-analyzer.md, .codex-plugin/plugin.json, both READMEs (workflow shape single-sourced as "Phases 0-6"; sub-SKILL leftovers removed; divergent inline pre-flight replaced with a pointer).
- **10-check S.U.P.E.R checklist** relocated to super-philosophy.md (agent-canonical; README table kept user-facing, verified byte-identical).
- **Installers**: legacy `"review"` dropped from BUNDLED_SKILLS; `.gitignore` gains `.worktrees/`.
- **AGENTS.md**: Truth Sources + Validation repaired (validate.sh is now the primary check).

## Aggregate Validation

```
[PASS] (a) reference existence
[PASS] (b) manifest <-> filesystem parity
[PASS] (c) version parity
[PASS] (d) JSON validity of manifests
[PASS] (e) ESM syntax of opencode-plugin.js
[PASS] (f) py_compile Python sources
[PASS] (g) exporter smoke test (fixture)
validate.sh: all 7 checks passed
```
- `bash -n` on all 4 installers: OK
- `rg` sweeps (sub-SKILL / phase-count variants): zero hits
- `git diff --check`: OK

## S.U.P.E.R Review

- [x] Batch passes the post-integration S.U.P.E.R checks for: U (phase model single-sourced), P (validation contracts + guard), R (drift sources removed), E (no new deps)

## Risk and Rollback

- Risk: low — docs/scripts only; validate.sh is additive; no workflow behavior changed.
- Rollback: revert this PR; no state migration involved.

## Project Governance

- Instruction surfaces: **updated** — `AGENTS.md` (Truth Sources + Validation).
- Memory surface: unavailable (no native surface; per AGENTS.md policy no repo fallback created).

## Notes

- Latent issue discovered during execution (out of scope, filed as follow-up): templates/progress.md title uses em-dash but export-progress.py regex matches ASCII hyphens only.
- Executed with the tiered cost model: 3 parallel coder lanes + independent review; integration review by orchestrator (L1 machine validation + L2 diff review).

---
_Part of [Spec-Driven Develop](https://github.com/zhu1090093659/spec-driven-develop) workflow_