### PR TITLE
[Batch P5-B1] Release v1.15.0 — docs reconciliation and version bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,14 +11,26 @@
       "name": "spec-driven-develop",
       "source": "./plugins/spec-driven-develop",
       "description": "Three complementary AI agent skills: (1) Spec-Driven Develop — automates full development workflow for large-scale complex tasks: project analysis, task decomposition, project governance, progress tracking, and execution; (2) Deep Discuss — structured deep discussion for problem analysis, brainstorming, and solution design; (3) Review SPD — findings-first code review for uncommitted changes, date-range commits, and branch/PR diffs.",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "author": {
         "name": "zhu1090093659"
       },
       "homepage": "https://github.com/zhu1090093659/spec_driven_develop",
       "repository": "https://github.com/zhu1090093659/spec_driven_develop",
       "license": "MIT",
-      "keywords": ["spec-driven", "workflow", "planning", "task-decomposition", "project-analysis", "deep-discuss", "brainstorming", "problem-analysis", "code-review", "review-spd", "bug-risk"]
+      "keywords": [
+        "spec-driven",
+        "workflow",
+        "planning",
+        "task-decomposition",
+        "project-analysis",
+        "deep-discuss",
+        "brainstorming",
+        "problem-analysis",
+        "code-review",
+        "review-spd",
+        "bug-risk"
+      ]
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,6 @@ These instructions apply to the whole repository.
 Run the standing consistency guard first; it subsumes the Python byte-compile check. Then use the closest checks for the changed surface:
 
 - `bash scripts/validate.sh`
-- `bash -n scripts/install-codex.sh scripts/install-cursor.sh scripts/install-opencode.sh scripts/install-all.sh`
+- `bash -n scripts/install-codex.sh scripts/install-cursor.sh scripts/install-opencode.sh scripts/install-agents.sh scripts/install-all.sh`
 - Targeted `rg` checks for newly required workflow language
 - `git diff --check`

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Phase 5  Confirm & Execute         Present plan summary, get confirmation,
 Phase 6  Archive                   Preserve all artifacts for traceability
 ```
 
+### Orchestrator-Centric Execution and Skills-Only Surface (Updated in v1.15)
+
+Execution is **orchestrator-centric**: the main agent owns progress and quality, and sub-agent dispatch is an economic decision, not a default. Orchestrator-direct execution (Tier 0) is the norm; a single `task-executor` coder (Tier 1) handles large or context-heavy batches; parallel lanes (Tier 2) require disjoint file sets, ≥ L effort per lane, independent verifiability, and ≤ 4 lanes. Review is likewise tiered — machine validation (L1) and the orchestrator's own diff review (L2) are the default, while an independent `code-reviewer` agent (L3) is reserved for Tier 2 lanes and high-risk changes. Reviewer agents verify lane diffs against acceptance criteria and commit fixes directly to lane branches; only APPROVED or FIXED lanes integrate.
+
+The plugin is **skills-only** — workflows are invoked through skills, not slash commands. All prompts follow a single-sourcing style rule (every sentence is a rule, a contract, or a pointer), with each topic defined in exactly one canonical reference. A new `scripts/install-agents.sh` syncs the bundled skills to `~/.agents/skills` for agents that read that shared directory.
+
 ### GitHub-Native Task Tracking and Batch PRs (Updated in v1.14)
 
 When a GitHub repository is detected, the workflow automatically creates **GitHub Issues** for every task, organized with **Milestones** (one per phase), **Labels** (priority, size, lane), and optionally a **GitHub Projects** board. Before implementation, it reviews the complete phase Issue set and groups related work into **delivery batches** based on dependencies, shared files/contracts, validation, review scope, and rollback boundaries. Issues remain atomic acceptance and telemetry records; a delivery batch owns the integration branch, aggregate validation, and PR.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,6 +78,12 @@ Phase 5  确认并执行                展示规划摘要，获得确认，
 Phase 6  归档                      保存所有工件以便溯源
 ```
 
+### 编排者中心执行与纯 Skill 形态（v1.15 更新）
+
+执行采用**编排者中心**模式：主 Agent 负责整体进度与质量，子 Agent 的分派是一个经济性决策，而非默认行为。默认由编排者直接执行（Tier 0）；单个 `task-executor` coder（Tier 1）处理较大或上下文较重的批次；并行泳道（Tier 2）则要求文件集互不相交、每条泳道 ≥ L 工作量、可独立验证且泳道数 ≤ 4。审查同样分级——机器校验（L1）与编排者自己的 diff 审查（L2）是默认，独立的 `code-reviewer` Agent（L3）只保留给 Tier 2 泳道和高风险变更。Reviewer 对照验收标准审查泳道 diff 并直接把修复提交到泳道分支；只有结论为 APPROVED 或 FIXED 的泳道才会被集成。
+
+插件为**纯 Skill** 形态——工作流通过 Skill 触发，不再使用斜杠命令。所有 Prompt 遵循单一来源风格规则（每个句子只能是规则、契约或指针），每个主题只在唯一一份权威参考里定义。新增的 `scripts/install-agents.sh` 会把 bundled skills 同步到 `~/.agents/skills`，供读取该共享目录的 Agent 使用。
+
 ### GitHub 原生任务追踪与批次 PR（v1.14 更新）
 
 当检测到 GitHub 仓库时，工作流会自动为每个任务创建 **GitHub Issue**，使用 **Milestone**（每个阶段一个）、**Label**（优先级、规模、泳道）组织，并可选创建 **GitHub Projects** 看板。开始开发前，工作流会审视当前阶段的完整 Issue 集，再按依赖、共享文件/契约、验证范围、审查边界和回滚边界组成 **Delivery Batch（交付批次）**。Issue 继续承担原子验收和逐任务遥测；交付批次承担集成分支、整体验证和 PR。

--- a/plugins/spec-driven-develop/.claude-plugin/plugin.json
+++ b/plugins/spec-driven-develop/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec-driven-develop",
   "displayName": "Spec-Driven Develop",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Three complementary AI agent skills: (1) Spec-Driven Develop — automates full development workflow for large-scale complex tasks: project analysis, task decomposition, project governance, progress tracking, and execution; (2) Deep Discuss — structured deep discussion for problem analysis, brainstorming, and solution design; (3) Review SPD — findings-first code review for uncommitted changes, date-range commits, and branch/PR diffs.",
   "author": {
     "name": "zhu1090093659",

--- a/plugins/spec-driven-develop/.codex-plugin/plugin.json
+++ b/plugins/spec-driven-develop/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-driven-develop",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Three complementary AI agent skills for spec-driven development, structured deep discussion, and findings-first code review.",
   "author": {
     "name": "zhu1090093659",

--- a/plugins/spec-driven-develop/skills/spec-driven-develop/SKILL.md
+++ b/plugins/spec-driven-develop/skills/spec-driven-develop/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   progress tracking setup, and then executes the plan within the same session. Keeps Issues as
   task-tracking units while batching related implementation into coherent reviewable PRs.
 metadata:
-  version: 1.14.0
+  version: 1.15.0
 ---
 
 # Spec-Driven Develop


### PR DESCRIPTION
> **Stacked on #43** — base is `batch/p4-b1-command-surface-removal`; retargets to `main` after the P1–P4 PRs merge. This is the final batch PR of the v1.15 transformation.

## Problem Statement (real usage problems addressed)

1. **README mirrors lagged the new execution model** — the v1.15 changes (orchestrator-centric tiered dispatch, the code-reviewer loop, skills-only surface, single-sourced prompts) were not yet documented for users.
2. **AGENTS.md validation list was incomplete** — the new `install-agents.sh` was missing from the syntax-check line.
3. **Version fields still read 1.14.0** despite a full transformation worth of user-visible change.

## Batch Rationale

One coherent release unit: documentation reconciliation (both mirrors in lockstep), instruction-surface finalization, and the 4-site version bump must land together so the released state is self-consistent.

## Included Issues

Closes #36
Closes #37
Closes #38

| Issue | Task | Acceptance | Targeted Validation |
|:------|:-----|:-----------|:--------------------|
| #36 | T5.1 README reconciliation (both mirrors) | complete | v1.15 section present in both; validate.sh green |
| #37 | T5.2 finalize AGENTS.md/CLAUDE.md | complete | install-agents.sh in validation list |
| #38 | T5.3 version bump ×4 + release commit | complete | validate.sh (c) 4-site parity PASS |

## Changes

- **`README.md` / `README.zh-CN.md`** (lockstep): new "Orchestrator-Centric Execution and Skills-Only Surface (v1.15)" section — tiered dispatch (Tier 0/1/2), tiered review (L1/L2/L3), the code-reviewer loop, skills-only surface, single-sourced prompts, `install-agents.sh`.
- **`AGENTS.md`**: `install-agents.sh` added to the `bash -n` validation line.
- **Version 1.14.0 → 1.15.0** across all 4 parity sites: SKILL.md frontmatter, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.claude-plugin/marketplace.json` (`.plugins[0].version`).

## Aggregate Validation

- `bash scripts/validate.sh` → **7/7 PASS** (incl. (c) 4-site version parity at 1.15.0)
- `git diff --check` clean
- README mirrors updated in lockstep (same section added to both)

## Independent Review

L1 machine validation + L2 orchestrator diff review. No L3 agent per the tiered-review criteria: documentation + version-metadata change with machine-verifiable acceptance (validate.sh (c) directly guards the version bump) and no contract/logic risk.

## S.U.P.E.R Review

- [x] S: this PR does exactly one thing — release; [x] P: 4-site version parity guarded by validate.sh; [x] R: docs sections are additive and independently revertable

## Risk and Rollback

- Risk: low — documentation and metadata only.
- Rollback: revert this PR; version returns to 1.14.0.

## Project Governance

- Instruction surfaces: **updated** — `AGENTS.md` (validation list).
- Memory surface: unavailable (no native surface; per AGENTS.md policy no repo fallback created).

---
_Part of [Spec-Driven Develop](https://github.com/zhu1090093659/spec-driven-develop) workflow_